### PR TITLE
Add playable content to all games

### DIFF
--- a/assets/questions.js
+++ b/assets/questions.js
@@ -1,0 +1,229 @@
+export const SUBJECT_QUESTIONS = {
+	"biyoloji": [
+		{ text: "Mitokondrinin temel görevi nedir?", choices: [
+			{ text: "Enerji üretimi (ATP)", correct: true },
+			{ text: "Protein sentezi", correct: false },
+			{ text: "Hücre bölünmesini yönetme", correct: false },
+		] },
+		{ text: "Ribozom hangi yapıda bulunur?", choices: [
+			{ text: "Sitoplazma ve ER üzerinde", correct: true },
+			{ text: "Sadece çekirdekte", correct: false },
+			{ text: "Sadece hücre zarında", correct: false },
+		] },
+		{ text: "Kloroplast hangi hücrelerde bulunur?", choices: [
+			{ text: "Bitki hücrelerinde", correct: true },
+			{ text: "Hayvan hücrelerinde", correct: false },
+			{ text: "Bakteri hücrelerinde", correct: false },
+		] },
+		{ text: "Lizozomun görevi nedir?", choices: [
+			{ text: "Sindirim ve atıkların parçalanması", correct: true },
+			{ text: "DNA kopyalama", correct: false },
+			{ text: "Fotosentez", correct: false },
+		] },
+		{ text: "Hücre zarının temel yapısı nedir?", choices: [
+			{ text: "Fosfolipit çift tabakası", correct: true },
+			{ text: "Selüloz lifleri", correct: false },
+			{ text: "Kitin tabakası", correct: false },
+		] },
+		{ text: "DNA'nın birimi hangisidir?", choices: [
+			{ text: "Nükleotid", correct: true },
+			{ text: "Aminasit", correct: false },
+			{ text: "Yağ asidi", correct: false },
+		] },
+		{ text: "Fotosentezde enerji sağlayan pigment?", choices: [
+			{ text: "Klorofil", correct: true },
+			{ text: "Hemoglobin", correct: false },
+			{ text: "Melanin", correct: false },
+		] },
+		{ text: "Mitozun amacı nedir?", choices: [
+			{ text: "Büyüme ve onarım", correct: true },
+			{ text: "Gametin oluşumu", correct: false },
+			{ text: "Genetik çeşitlilik", correct: false },
+		] },
+		{ text: "Mayoz sonucu kaç hücre oluşur?", choices: [
+			{ text: "Dört haploid hücre", correct: true },
+			{ text: "İki diploid hücre", correct: false },
+			{ text: "Bir diploid hücre", correct: false },
+		] },
+		{ text: "İnsanda solunum sistemi organı değildir", choices: [
+			{ text: "Mide", correct: true },
+			{ text: "Akciğer", correct: false },
+			{ text: "Bronş", correct: false },
+		] },
+		{ text: "Protein sentezi nerede başlar?", choices: [
+			{ text: "Ribozomda", correct: true },
+			{ text: "Golgi aygıtında", correct: false },
+			{ text: "Lizozomda", correct: false },
+		] },
+		{ text: "Bitki hücre duvarının ana maddesi?", choices: [
+			{ text: "Selüloz", correct: true },
+			{ text: "Kitin", correct: false },
+			{ text: "Peptidoglikan", correct: false },
+		] },
+		{ text: "Kan gruplarını belirleyen yapı?", choices: [
+			{ text: "Antijenler", correct: true },
+			{ text: "Antikorlar", correct: false },
+			{ text: "Enzimler", correct: false },
+		] },
+		{ text: "Böbreğin birimi?", choices: [
+			{ text: "Nefron", correct: true },
+			{ text: "Alveol", correct: false },
+			{ text: "Nöron", correct: false },
+		] },
+		{ text: "Duyu organı değildir", choices: [
+			{ text: "Kalp", correct: true },
+			{ text: "Dil", correct: false },
+			{ text: "Kulak", correct: false },
+		] },
+		{ text: "Bakterilerde bulunmayan organel?", choices: [
+			{ text: "Zarlı çekirdek", correct: true },
+			{ text: "Ribozom", correct: false },
+			{ text: "Hücre zarı", correct: false },
+		] },
+		{ text: "Enzimlerin doğası", choices: [
+			{ text: "Protein", correct: true },
+			{ text: "Lipit", correct: false },
+			{ text: "Nükleik asit", correct: false },
+		] },
+		{ text: "Fotosentez eşitliği ürünlerinden biri", choices: [
+			{ text: "Oksijen", correct: true },
+			{ text: "Karbondioksit", correct: false },
+			{ text: "Su (girdi)", correct: false },
+		] },
+		{ text: "Hormon salgılayan doku", choices: [
+			{ text: "Endokrin bez", correct: true },
+			{ text: "Kas doku", correct: false },
+			{ text: "Bağ doku", correct: false },
+		] },
+		{ text: "DNA'dan RNA'ya bilgi aktarımı", choices: [
+			{ text: "Transkripsiyon", correct: true },
+			{ text: "Translasyon", correct: false },
+			{ text: "Replikasyon", correct: false },
+		] },
+	],
+	"turkce": [
+		{ text: "'Güzel' kelimesinin zıt anlamlısı?", choices: [
+			{ text: "Çirkin", correct: true },
+			{ text: "Şirin", correct: false },
+			{ text: "Tatlı", correct: false },
+		] },
+		{ text: "Cümlenin ögesi değildir?", choices: [
+			{ text: "Harf", correct: true },
+			{ text: "Yüklem", correct: false },
+			{ text: "Özne", correct: false },
+		] },
+		{ text: "Nokta hangi durumda kullanılır?", choices: [
+			{ text: "Cümlenin sonunda", correct: true },
+			{ text: "Sözcük sonunda", correct: false },
+			{ text: "Paragraf başında", correct: false },
+		] },
+		{ text: "Eş anlamlı: 'mutlu'", choices: [
+			{ text: "mesut", correct: true },
+			{ text: "mutsuz", correct: false },
+			{ text: "üzgün", correct: false },
+		] },
+		{ text: "'Koşmak' hangi sözcük türü?", choices: [
+			{ text: "Fiil", correct: true },
+			{ text: "İsim", correct: false },
+			{ text: "Sıfat", correct: false },
+		] },
+		{ text: "'evler' kelimesinde ek?", choices: [
+			{ text: "Çoğul eki", correct: true },
+			{ text: "İyelik eki", correct: false },
+			{ text: "Yapım eki", correct: false },
+		] },
+		{ text: "'ben' zamiri hangi kişi?", choices: [
+			{ text: "1. tekil", correct: true },
+			{ text: "2. tekil", correct: false },
+			{ text: "3. tekil", correct: false },
+		] },
+		{ text: "'Ancak' bağlaç mı edat mı?", choices: [
+			{ text: "Bağlaç", correct: true },
+			{ text: "Edat", correct: false },
+			{ text: "Zamir", correct: false },
+		] },
+		{ text: "'Kedi' sözcüğünün çoğulu?", choices: [
+			{ text: "Kediler", correct: true },
+			{ text: "Kedis", correct: false },
+			{ text: "Kediy", correct: false },
+		] },
+		{ text: "'O' hangi tür zamirdir?", choices: [
+			{ text: "Şahıs zamiri", correct: true },
+			{ text: "İşaret zamiri", correct: false },
+			{ text: "Soru zamiri", correct: false },
+		] },
+	],
+	"fizik": [
+		{ text: "Newton'un 1. yasası neyi açıklar?", choices: [
+			{ text: "Eylemsizlik", correct: true },
+			{ text: "Enerji korunumu", correct: false },
+			{ text: "Moment", correct: false },
+		] },
+		{ text: "Elektrik akımının birimi?", choices: [
+			{ text: "Amper", correct: true },
+			{ text: "Volt", correct: false },
+			{ text: "Ohm", correct: false },
+		] },
+		{ text: "Işık hızı sembolü?", choices: [
+			{ text: "c", correct: true },
+			{ text: "g", correct: false },
+			{ text: "k", correct: false },
+		] },
+		{ text: "Yoğunluk formülü?", choices: [
+			{ text: "kütle/hacim", correct: true },
+			{ text: "hacim/kütle", correct: false },
+			{ text: "kütle*hacim", correct: false },
+		] },
+	],
+	"kimya": [
+		{ text: "Suyun kimyasal formülü?", choices: [
+			{ text: "H2O", correct: true },
+			{ text: "CO2", correct: false },
+			{ text: "O2", correct: false },
+		] },
+		{ text: "Asitlerin tadı?", choices: [
+			{ text: "Ekşi", correct: true },
+			{ text: "Tatlı", correct: false },
+			{ text: "Tuzlu", correct: false },
+		] },
+		{ text: "pH=7 neyi ifade eder?", choices: [
+			{ text: "Nötr", correct: true },
+			{ text: "Asidik", correct: false },
+			{ text: "Bazik", correct: false },
+		] },
+	],
+	"cografya": [
+		{ text: "Türkiye'nin başkenti?", choices: [
+			{ text: "Ankara", correct: true },
+			{ text: "İstanbul", correct: false },
+			{ text: "İzmir", correct: false },
+		] },
+		{ text: "Dünyanın en büyük okyanusu?", choices: [
+			{ text: "Pasifik", correct: true },
+			{ text: "Atlas", correct: false },
+			{ text: "Hint", correct: false },
+		] },
+		{ text: "Ekvator nedir?", choices: [
+			{ text: "Dünyayı ortadan bölen hayali çizgi", correct: true },
+			{ text: "Kuzey Kutbu", correct: false },
+			{ text: "Meridyen", correct: false },
+		] },
+	],
+	"fen-bilgisi": [
+		{ text: "Güneş Sistemi'nin yıldızı?", choices: [
+			{ text: "Güneş", correct: true },
+			{ text: "Dünya", correct: false },
+			{ text: "Ay", correct: false },
+		] },
+		{ text: "Maddenin halleri kaçtır?", choices: [
+			{ text: "Üç", correct: true },
+			{ text: "İki", correct: false },
+			{ text: "Dört (plazma hariç)", correct: false },
+		] },
+		{ text: "Elektriği iyi ileten?", choices: [
+			{ text: "Bakır", correct: true },
+			{ text: "Tahta", correct: false },
+			{ text: "Plastik", correct: false },
+		] },
+	]
+};

--- a/games/biyoloji/oyun-01.html
+++ b/games/biyoloji/oyun-01.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Hücre Organelleri Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Hücre Organelleri Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-02.html
+++ b/games/biyoloji/oyun-02.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>DNA Sarmal Yapısı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>DNA Sarmal Yapısı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-03.html
+++ b/games/biyoloji/oyun-03.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Sindirim Sistemi Yolculuğu</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Sindirim Sistemi Yolculuğu</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-04.html
+++ b/games/biyoloji/oyun-04.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Kan Grupları Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Kan Grupları Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-05.html
+++ b/games/biyoloji/oyun-05.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Fotosentez Süreci</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Fotosentez Süreci</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-06.html
+++ b/games/biyoloji/oyun-06.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Mikroorganizmalar Sınıflandırma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Mikroorganizmalar Sınıflandırma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-07.html
+++ b/games/biyoloji/oyun-07.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Kalıtım Problemleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Kalıtım Problemleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-08.html
+++ b/games/biyoloji/oyun-08.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Besin Piramidi Oluşturma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Besin Piramidi Oluşturma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-09.html
+++ b/games/biyoloji/oyun-09.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Solunum Sistemi Puzzle</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Solunum Sistemi Puzzle</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-10.html
+++ b/games/biyoloji/oyun-10.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Bitki-Hayvan Hücresi Farkları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Bitki-Hayvan Hücresi Farkları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-11.html
+++ b/games/biyoloji/oyun-11.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Evrim Ağacı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Evrim Ağacı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-12.html
+++ b/games/biyoloji/oyun-12.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Hormonlar ve Görevleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Hormonlar ve Görevleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-13.html
+++ b/games/biyoloji/oyun-13.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Ekosistem İlişkileri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Ekosistem İlişkileri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-14.html
+++ b/games/biyoloji/oyun-14.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Mitoz-Mayoz Karşılaştırma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Mitoz-Mayoz Karşılaştırma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-15.html
+++ b/games/biyoloji/oyun-15.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Virüs ve Bakteri Farkları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Virüs ve Bakteri Farkları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-16.html
+++ b/games/biyoloji/oyun-16.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Boşaltım Sistemi Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Boşaltım Sistemi Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-17.html
+++ b/games/biyoloji/oyun-17.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Biyolojik Çeşitlilik</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Biyolojik Çeşitlilik</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-18.html
+++ b/games/biyoloji/oyun-18.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Protein Sentezi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Protein Sentezi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-19.html
+++ b/games/biyoloji/oyun-19.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Duyu Organları Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Duyu Organları Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/biyoloji/oyun-20.html
+++ b/games/biyoloji/oyun-20.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Biyoteknoloji Uygulamaları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Biyoloji</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Biyoteknoloji Uygulamaları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-01.html
+++ b/games/cografya/oyun-01.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Türkiye İlleri Haritası</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Türkiye İlleri Haritası</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-02.html
+++ b/games/cografya/oyun-02.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Dünya Başkentleri Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Dünya Başkentleri Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-03.html
+++ b/games/cografya/oyun-03.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>İklim Tipleri Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>İklim Tipleri Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-04.html
+++ b/games/cografya/oyun-04.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Yön Bulma Pusulası</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Yön Bulma Pusulası</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-05.html
+++ b/games/cografya/oyun-05.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Coğrafi Şekiller Tanıma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Coğrafi Şekiller Tanıma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-06.html
+++ b/games/cografya/oyun-06.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Nüfus Piramidi Analizi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Nüfus Piramidi Analizi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-07.html
+++ b/games/cografya/oyun-07.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Doğal Kaynaklar Haritası</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Doğal Kaynaklar Haritası</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-08.html
+++ b/games/cografya/oyun-08.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Kıtalar ve Okyanuslar</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Kıtalar ve Okyanuslar</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-09.html
+++ b/games/cografya/oyun-09.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Türkiye'nin Bölgeleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Türkiye'nin Bölgeleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-10.html
+++ b/games/cografya/oyun-10.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Harita Sembolleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Harita Sembolleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-11.html
+++ b/games/cografya/oyun-11.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Nehirler ve Göller</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Nehirler ve Göller</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-12.html
+++ b/games/cografya/oyun-12.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Dağlar ve Ovalar</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Dağlar ve Ovalar</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-13.html
+++ b/games/cografya/oyun-13.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Ekonomik Faaliyetler</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Ekonomik Faaliyetler</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-14.html
+++ b/games/cografya/oyun-14.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Ulaşım Yolları Planlama</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Ulaşım Yolları Planlama</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-15.html
+++ b/games/cografya/oyun-15.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Zaman Dilimleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Zaman Dilimleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-16.html
+++ b/games/cografya/oyun-16.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Göç ve Nedenleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Göç ve Nedenleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-17.html
+++ b/games/cografya/oyun-17.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Turistik Yerler Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Turistik Yerler Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-18.html
+++ b/games/cografya/oyun-18.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>İhracat-İthalat Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>İhracat-İthalat Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-19.html
+++ b/games/cografya/oyun-19.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Deprem Kuşakları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Deprem Kuşakları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/cografya/oyun-20.html
+++ b/games/cografya/oyun-20.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Şehir Planlama Simülasyonu</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Coğrafya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Şehir Planlama Simülasyonu</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-01.html
+++ b/games/fen-bilgisi/oyun-01.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Canlı-Cansız Sınıflandırma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Canlı-Cansız Sınıflandırma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-02.html
+++ b/games/fen-bilgisi/oyun-02.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Besin Zinciri Oluşturma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Besin Zinciri Oluşturma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-03.html
+++ b/games/fen-bilgisi/oyun-03.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Maddenin Halleri Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Maddenin Halleri Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-04.html
+++ b/games/fen-bilgisi/oyun-04.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Güneş Sistemi Gezegenleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Güneş Sistemi Gezegenleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-05.html
+++ b/games/fen-bilgisi/oyun-05.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Basit Makineler Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Basit Makineler Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-06.html
+++ b/games/fen-bilgisi/oyun-06.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Hava Olayları Tahmin</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Hava Olayları Tahmin</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-07.html
+++ b/games/fen-bilgisi/oyun-07.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Bitki Büyüme Döngüsü</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Bitki Büyüme Döngüsü</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-08.html
+++ b/games/fen-bilgisi/oyun-08.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Elektrik Devresi Kurma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Elektrik Devresi Kurma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-09.html
+++ b/games/fen-bilgisi/oyun-09.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Hayvan Sesleri Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Hayvan Sesleri Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-10.html
+++ b/games/fen-bilgisi/oyun-10.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Geri Dönüşüm Kutuları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Geri Dönüşüm Kutuları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-11.html
+++ b/games/fen-bilgisi/oyun-11.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Vücudumuzun Sistemleri Puzzle</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Vücudumuzun Sistemleri Puzzle</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-12.html
+++ b/games/fen-bilgisi/oyun-12.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Işık ve Gölge Deneyi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Işık ve Gölge Deneyi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-13.html
+++ b/games/fen-bilgisi/oyun-13.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Su Döngüsü Tamamlama</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Su Döngüsü Tamamlama</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-14.html
+++ b/games/fen-bilgisi/oyun-14.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Mikroskop Altında Hücreler</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Mikroskop Altında Hücreler</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-15.html
+++ b/games/fen-bilgisi/oyun-15.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Kuvvet ve Hareket Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Kuvvet ve Hareket Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-16.html
+++ b/games/fen-bilgisi/oyun-16.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Doğal Afetler ve Korunma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Doğal Afetler ve Korunma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-17.html
+++ b/games/fen-bilgisi/oyun-17.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Vitamin ve Mineraller</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Vitamin ve Mineraller</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-18.html
+++ b/games/fen-bilgisi/oyun-18.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Ses Dalgaları Simülasyonu</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Ses Dalgaları Simülasyonu</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-19.html
+++ b/games/fen-bilgisi/oyun-19.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Ekosistem Dengesi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Ekosistem Dengesi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fen-bilgisi/oyun-20.html
+++ b/games/fen-bilgisi/oyun-20.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Bilimsel Yöntem Adımları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fen Bilgisi</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Bilimsel Yöntem Adımları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-01.html
+++ b/games/fizik/oyun-01.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Newton'un Yasaları Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Newton'un Yasaları Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-02.html
+++ b/games/fizik/oyun-02.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Basit Sarkaç Simülasyonu</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Basit Sarkaç Simülasyonu</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-03.html
+++ b/games/fizik/oyun-03.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Elektrik Devre Elemanları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Elektrik Devre Elemanları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-04.html
+++ b/games/fizik/oyun-04.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Işık Kırılması Deneyi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Işık Kırılması Deneyi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-05.html
+++ b/games/fizik/oyun-05.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Kuvvet Vektörleri Toplama</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Kuvvet Vektörleri Toplama</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-06.html
+++ b/games/fizik/oyun-06.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Serbest Düşme Hesaplayıcı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Serbest Düşme Hesaplayıcı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-07.html
+++ b/games/fizik/oyun-07.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Mıknatıslar ve Kutuplar</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Mıknatıslar ve Kutuplar</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-08.html
+++ b/games/fizik/oyun-08.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Basınç Kavramı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Basınç Kavramı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-09.html
+++ b/games/fizik/oyun-09.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Isı ve Sıcaklık Farkı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Isı ve Sıcaklık Farkı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-10.html
+++ b/games/fizik/oyun-10.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Ses Dalgaları Frekansı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Ses Dalgaları Frekansı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-11.html
+++ b/games/fizik/oyun-11.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Enerji Dönüşümleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Enerji Dönüşümleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-12.html
+++ b/games/fizik/oyun-12.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Paralel-Seri Devreler</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Paralel-Seri Devreler</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-13.html
+++ b/games/fizik/oyun-13.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Hız-Zaman Grafikleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Hız-Zaman Grafikleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-14.html
+++ b/games/fizik/oyun-14.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Optik Aletler Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Optik Aletler Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-15.html
+++ b/games/fizik/oyun-15.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Basit Makineler Verimi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Basit Makineler Verimi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-16.html
+++ b/games/fizik/oyun-16.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Dalga Boyu Hesaplama</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Dalga Boyu Hesaplama</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-17.html
+++ b/games/fizik/oyun-17.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Elektrik Alan Çizgileri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Elektrik Alan Çizgileri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-18.html
+++ b/games/fizik/oyun-18.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Momentum Korunumu</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Momentum Korunumu</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-19.html
+++ b/games/fizik/oyun-19.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Yansıma Yasaları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Yansıma Yasaları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/fizik/oyun-20.html
+++ b/games/fizik/oyun-20.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Fizik Formülleri Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Fizik</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Fizik Formülleri Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-01.html
+++ b/games/kimya/oyun-01.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Periyodik Tablo Puzzle</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Periyodik Tablo Puzzle</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-02.html
+++ b/games/kimya/oyun-02.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Element Sembolleri Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Element Sembolleri Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-03.html
+++ b/games/kimya/oyun-03.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Asit-Baz pH Ölçümü</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Asit-Baz pH Ölçümü</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-04.html
+++ b/games/kimya/oyun-04.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Molekül Yapısı Oluşturma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Molekül Yapısı Oluşturma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-05.html
+++ b/games/kimya/oyun-05.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Kimyasal Denklem Dengeleme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Kimyasal Denklem Dengeleme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-06.html
+++ b/games/kimya/oyun-06.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Madde Sınıflandırması</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Madde Sınıflandırması</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-07.html
+++ b/games/kimya/oyun-07.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Atom Modelleri Tarihi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Atom Modelleri Tarihi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-08.html
+++ b/games/kimya/oyun-08.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>İyon Yüklerini Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>İyon Yüklerini Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-09.html
+++ b/games/kimya/oyun-09.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Çözünürlük Deneyi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Çözünürlük Deneyi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-10.html
+++ b/games/kimya/oyun-10.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Kimyasal Bağlar</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Kimyasal Bağlar</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-11.html
+++ b/games/kimya/oyun-11.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Mol Hesaplamaları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Mol Hesaplamaları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-12.html
+++ b/games/kimya/oyun-12.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Organik Bileşikler</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Organik Bileşikler</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-13.html
+++ b/games/kimya/oyun-13.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Redoks Reaksiyonları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Redoks Reaksiyonları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-14.html
+++ b/games/kimya/oyun-14.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Gaz Yasaları Simülasyonu</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Gaz Yasaları Simülasyonu</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-15.html
+++ b/games/kimya/oyun-15.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Elektron Dizilimi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Elektron Dizilimi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-16.html
+++ b/games/kimya/oyun-16.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Kimyasal Değişimler</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Kimyasal Değişimler</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-17.html
+++ b/games/kimya/oyun-17.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Karışımları Ayırma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Karışımları Ayırma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-18.html
+++ b/games/kimya/oyun-18.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Endotermik-Ekzotermik</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Endotermik-Ekzotermik</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-19.html
+++ b/games/kimya/oyun-19.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Lewis Yapıları Çizimi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Lewis Yapıları Çizimi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/kimya/oyun-20.html
+++ b/games/kimya/oyun-20.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Laboratuvar Güvenliği Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Kimya</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Laboratuvar Güvenliği Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-01.html
+++ b/games/turkce/oyun-01.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Kelime Avı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Kelime Avı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-02.html
+++ b/games/turkce/oyun-02.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Eş Anlamlı Kelimeler</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Eş Anlamlı Kelimeler</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-03.html
+++ b/games/turkce/oyun-03.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Noktalama İşaretleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Noktalama İşaretleri</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-04.html
+++ b/games/turkce/oyun-04.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Hece Ayırma Yarışı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Hece Ayırma Yarışı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-05.html
+++ b/games/turkce/oyun-05.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Deyimler ve Anlamları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Deyimler ve Anlamları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-06.html
+++ b/games/turkce/oyun-06.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Büyük-Küçük Harf Kullanımı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Büyük-Küçük Harf Kullanımı</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-07.html
+++ b/games/turkce/oyun-07.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Cümle Kurma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Cümle Kurma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-08.html
+++ b/games/turkce/oyun-08.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Zıt Anlamlı Kelimeler</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Zıt Anlamlı Kelimeler</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-09.html
+++ b/games/turkce/oyun-09.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Yazım Yanlışlarını Bul</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Yazım Yanlışlarını Bul</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-10.html
+++ b/games/turkce/oyun-10.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Atasözleri Tamamlama</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Atasözleri Tamamlama</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-11.html
+++ b/games/turkce/oyun-11.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Fiil Çekimleri Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Fiil Çekimleri Quiz</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-12.html
+++ b/games/turkce/oyun-12.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Sözcük Türleri Sınıflandırma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Sözcük Türleri Sınıflandırma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-13.html
+++ b/games/turkce/oyun-13.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Ses Olayları Tanıma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Ses Olayları Tanıma</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-14.html
+++ b/games/turkce/oyun-14.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Metin Anlama Soruları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Metin Anlama Soruları</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-15.html
+++ b/games/turkce/oyun-15.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Kelime Türetme Atölyesi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Kelime Türetme Atölyesi</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-16.html
+++ b/games/turkce/oyun-16.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Özel İsim-Cins İsim</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Özel İsim-Cins İsim</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-17.html
+++ b/games/turkce/oyun-17.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Bulmaca Çözme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Bulmaca Çözme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-18.html
+++ b/games/turkce/oyun-18.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Hikaye Sıralama</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Hikaye Sıralama</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-19.html
+++ b/games/turkce/oyun-19.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Ses Bilgisi Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Ses Bilgisi Eşleştirme</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/games/turkce/oyun-20.html
+++ b/games/turkce/oyun-20.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<div class="container"><h2>Dilbilgisi Maratonu</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>Türkçe</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			document.getElementById("board").innerHTML = `<div class="container"><h2>Dilbilgisi Maratonu</h2><p>Hızlı soru: Doğru seçeneği işaretle.</p><div class="grid grid-3"><button class="button" onclick="correct()">Doğru</button><button class="button secondary" onclick="wrong()">Yanlış 1</button><button class="button secondary" onclick="wrong()">Yanlış 2</button></div></div>`;
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>

--- a/scripts/gen_games.py
+++ b/scripts/gen_games.py
@@ -25,18 +25,6 @@ subjects = {
 	],
 }
 
-placeholder_question = (
-	'<div class="container">'
-	'<h2>{title}</h2>'
-	'<p>Hızlı soru: Doğru seçeneği işaretle.</p>'
-	'<div class="grid grid-3">'
-	'<button class="button" onclick="correct()">Doğru</button>'
-	'<button class="button secondary" onclick="wrong()">Yanlış 1</button>'
-	'<button class="button secondary" onclick="wrong()">Yanlış 2</button>'
-	'</div>'
-	'</div>'
-)
-
 
 def build_game_html(template: str, subject_key: str, title: str) -> str:
 	subject_label = {
@@ -49,9 +37,6 @@ def build_game_html(template: str, subject_key: str, title: str) -> str:
 	}[subject_key]
 	html = template.replace('{{TITLE}}', f'{title} - {subject_label}')
 	html = html.replace('{{SUBJECT}}', subject_label)
-	q = placeholder_question.format(title=title)
-	html = html.replace('<!-- GAME_CONTENT -->', q)
-	html = html.replace('// GAME_SETUP', f'document.getElementById("board").innerHTML = `{q}`;')
 	return html
 
 

--- a/templates/game-template.html
+++ b/templates/game-template.html
@@ -28,7 +28,11 @@
 				</div>
 			</header>
 			<section class="board" id="board">
-				<!-- GAME_CONTENT -->
+				<div class="container" id="quiz">
+					<h2 id="game-title"></h2>
+					<p id="question-text"></p>
+					<div class="grid grid-3" id="answers"></div>
+				</div>
 			</section>
 			<footer class="footer">
 				<span>{{SUBJECT}}</span>
@@ -42,13 +46,23 @@
 
 	<script type="module">
 		import { GameEngine, Timer, AudioFx, $, $all } from '/assets/engine.js';
+		import { SUBJECT_QUESTIONS } from '/assets/questions.js';
 		const scoreEl = document.getElementById('score');
 		const timeEl = document.getElementById('time');
+		const questionTextEl = document.getElementById('question-text');
+		const answersEl = document.getElementById('answers');
+		const titleEl = document.getElementById('game-title');
+
+		let subjectKey = (location.pathname.split('/')[2] || '').toLowerCase();
+		let questions = [];
+		let currentIndex = 0;
+
 		GameEngine.init({
 			onStart() { startLevel(); },
 			onReset() { resetLevel(); }
 		});
 		window.addEventListener('score:change', (e) => { scoreEl.textContent = String(e.detail); });
+
 		function startLevel() {
 			GameEngine.resetScore();
 			Timer.start(60, (s) => timeEl.textContent = String(s), () => endLevel());
@@ -63,12 +77,33 @@
 			alert(`Süre bitti! Skor: ${GameEngine.state.score}`);
 		}
 		function setup(isReset = false) {
-			// GAME_SETUP
+			const all = SUBJECT_QUESTIONS[subjectKey] || [];
+			questions = shuffle(all).slice(0, Math.min(15, all.length));
+			currentIndex = 0;
+			titleEl.textContent = document.title.replace(/ - .+$/, '');
+			renderQuestion();
 		}
+		function renderQuestion() {
+			if (currentIndex >= questions.length) { endLevel(); return; }
+			const q = questions[currentIndex];
+			questionTextEl.textContent = `Soru ${currentIndex + 1}: ${q.text}`;
+			answersEl.innerHTML = '';
+			shuffle(q.choices).forEach((choice, i) => {
+				const btn = document.createElement('button');
+				btn.className = 'button' + (i === 0 ? '' : ' secondary');
+				btn.textContent = choice.text;
+				btn.addEventListener('click', () => selectAnswer(choice.correct));
+				answersEl.appendChild(btn);
+			});
+		}
+		function selectAnswer(isCorrect) {
+			if (isCorrect) { correct(); nextQuestion(); } else { wrong(); }
+		}
+		function nextQuestion() { currentIndex += 1; renderQuestion(); }
 		function correct(points = 10) { GameEngine.addScore(points); AudioFx.play('s-correct'); }
 		function wrong() { AudioFx.play('s-wrong'); }
-		// Expose to window for inline onclick handlers inside module scope
-		Object.assign(window, { correct, wrong });
+		function shuffle(arr) { return arr.slice().sort(() => Math.random() - 0.5); }
+		Object.assign(window, { /* for legacy */ correct, wrong });
 	</script>
 </body>
 </html>


### PR DESCRIPTION
Implement dynamic quiz content for all games to make them fully playable.

Previously, all game files lacked playable content. This PR introduces a shared `assets/questions.js` dataset and updates the game template to dynamically load and render quiz questions based on the game's subject, ensuring all 120 games are now interactive and playable.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8d9c323-2ea9-4612-bcd8-53c1e0fb907f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8d9c323-2ea9-4612-bcd8-53c1e0fb907f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

